### PR TITLE
Pagination fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ _site/
 .sass-cache/
 log.txt
 _config_testserver.yml
+.project

--- a/_config.yml
+++ b/_config.yml
@@ -53,7 +53,7 @@ logo: "logo.png"
 #               /____/
 #
 gems: [jekyll-paginate]
-paginate: 20                # Paginates all X entries
+paginate: 15                # Paginates all X entries
 paginate_path: "page:num"   # Pagination path › Important for blog page in /blog/ to work
 
 

--- a/_includes/_pagination.html
+++ b/_includes/_pagination.html
@@ -27,16 +27,16 @@
 <nav id="pagination">
     {% if paginator.previous_page %}
       {% if paginator.previous_page == 1 %}
-      <a class="radius button small" href="{{ site.url }}/blog/" title="{{ site.data.language.previous_posts }}">&laquo; {{ site.data.language.previous_posts }}</a>
+      <a class="radius button small" href="{{ site.url }}/" title="{{ site.data.language.previous_posts }}">&laquo; {{ site.data.language.previous_posts }}</a>
       {% else %}
-      <a class="radius button small" href="{{ site.url }}/blog/page{{ paginator.previous_page }}/" title="{{ site.data.language.previous_posts }}">&laquo; {{ site.data.language.previous }}</a>
+      <a class="radius button small" href="{{ site.url }}/page{{ paginator.previous_page }}/" title="{{ site.data.language.previous_posts }}">&laquo; {{ site.data.language.previous }}</a>
       {% endif %}
     {% endif %}
 
     <a class="radius button small" href="{{ site.url }}/blog/archive/" title="{{ site.data.language.blog_archive }}">{{ site.data.language.blog_archive }}</a>
 
     {% if paginator.next_page %}
-    <a class="radius button small" href="{{ site.url }}/blog/page{{ paginator.next_page }}/" title="{{ site.data.language.next_posts }}">{{ site.data.language.next }} &raquo;</a>
+    <a class="radius button small" href="{{ site.url }}/page{{ paginator.next_page }}/" title="{{ site.data.language.next_posts }}">{{ site.data.language.next }} &raquo;</a>
     {% endif %}
   </nav>
 

--- a/_layouts/blog-under-page.html
+++ b/_layouts/blog-under-page.html
@@ -5,34 +5,36 @@ format: blog-index
 <div class="row t30">
 	<div class="medium-8 columns{% if page.sidebar == NULL %} medium-offset-2 end{% endif %}{% if page.sidebar == "left" %} medium-push-4{% endif %}">
 		<article itemscope itemtype="http://schema.org/Article">
-			<header>
-				{% if page.image.title %}
-				<figure>
-					<img src="{{ site.urlimg }}{{ page.image.title }}" width="970" alt="{{ page.title escape_once }}" itemprop="image">
+			{% if {{paginator.page}} == 1 %}	<!-- only display sidebar on the frontpage -->
+				<header>
+					{% if page.image.title %}
+					<figure>
+						<img src="{{ site.urlimg }}{{ page.image.title }}" width="970" alt="{{ page.title escape_once }}" itemprop="image">
 
-					{% if page.image.caption_url && page.image.caption %}
-					<figcaption class="text-right">
-						<a href="{{ page.image.caption_url }}">{{ page.image.caption }}</a>
-					</figcaption>
-					{% elsif page.image.caption %}
-					<figcaption class="text-right">
-						{{ page.image.caption }}
-					</figcaption>
+						{% if page.image.caption_url && page.image.caption %}
+						<figcaption class="text-right">
+							<a href="{{ page.image.caption_url }}">{{ page.image.caption }}</a>
+						</figcaption>
+						{% elsif page.image.caption %}
+						<figcaption class="text-right">
+							{{ page.image.caption }}
+						</figcaption>
+						{% endif %}
+					</figure>
 					{% endif %}
-				</figure>
+
+
+					<div itemprop="name">
+						{% if page.subheadline %}<p class="subheadline">{{ page.subheadline }}</p>{% endif %}
+						<h1>{{ page.title }}</h1>
+					</div>
+				</header>
+
+				{% if page.teaser %}
+				<p class="teaser" itemprop="description">
+					{{ page.teaser }}
+				</p>
 				{% endif %}
-
-				<div itemprop="name">
-					{% if page.subheadline %}<p class="subheadline">{{ page.subheadline }}</p>{% endif %}
-					<h1>{{ page.title }}</h1>
-				</div>
-			</header>
-
-
-			{% if page.teaser %}
-			<p class="teaser" itemprop="description">
-				{{ page.teaser }}
-			</p>
 			{% endif %}
 
 			<div itemprop="articleSection">
@@ -53,17 +55,19 @@ format: blog-index
 	</div><!-- /.medium-8.columns -->
 
 
-	{% if page.sidebar == "left" %}
-	<div class="medium-4 columns medium-pull-8">
-		{% include _sidebar.html %}
-	</div><!-- /.medium-4.columns -->
-	{% endif %}
+	{% if {{paginator.page}} == 1 %}		<!-- only display sidebar on the frontpage -->
+		{% if page.sidebar == "left" %}
+		<div class="medium-4 columns medium-pull-8">
+			{% include _sidebar.html %}
+		</div><!-- /.medium-4.columns -->
+		{% endif %}
 
-
-	{% if page.sidebar == "right" %}
-	<div class="medium-4 columns">
-		{% include _sidebar.html %}
-	</div><!-- /.medium-4.columns -->
+		{% if page.sidebar == "right" %}
+		<div class="medium-4 columns">
+			{% include _sidebar.html %}
+		</div><!-- /.medium-4.columns -->
+		{% endif %}
 	{% endif %}
+	
 </div><!-- /.row -->
 


### PR DESCRIPTION
Fix für das Pagination-Problem mit dem Custom-Layout auf der Hauptseite (Blog mit Sidebar & Teaser).

Inhalt des Pull-Requests:
* Ändern der maximalen Posts pro Seite (von 20 auf 15)
* "Next" / "Previous" Buttons referenzieren korrekte URLs
* Überschrift, Teaser und Sidebar werden nur auf der Hauptseite gezeigt, aber nicht wenn man auf "Next" klickt.